### PR TITLE
support Meter Plus

### DIFF
--- a/switchbot.go
+++ b/switchbot.go
@@ -52,6 +52,8 @@ const (
 	ContactSensor PhysicalDeviceType = "Contact Sensor"
 	// ColorBulb is SwitchBot Color Bulb Model No. W1401400
 	ColorBulb PhysicalDeviceType = "Color Bulb"
+	// MeterPlusJP is SwitchBot Thermometer and Hygrometer Plus (JP) Model No. W2201500 / (US) Model No. W2301500
+	MeterPlus PhysicalDeviceType = "MeterPlus"
 )
 
 type VirtualDeviceType string


### PR DESCRIPTION
SwitchBot温湿度計プラスを追加しました。

JPとUSモデルが有るようですが、応答に区別はなかったので同一にしています。

https://github.com/OpenWonderLabs/SwitchBotAPI/commit/bd98ef149c963b68724b7a65062ac10a7f024894

```
curl \
  -H "Authorization: "" \
  "https://api.switch-bot.com/v1.0/devices/ABC/status"
{"statusCode":100,"body":{"deviceId":"ABC","deviceType":"MeterPlus","hubDeviceId":"XYZ","humidity":60,"temperature":27.3},"message":"success"}%
```