### PR TITLE
If you want to use go module in more than 2 versions, you need to change the path, so make the change

### DIFF
--- a/device_test.go
+++ b/device_test.go
@@ -11,7 +11,7 @@ import (
 	"time"
 
 	"github.com/google/go-cmp/cmp"
-	"github.com/nasa9084/go-switchbot"
+	"github.com/nasa9084/go-switchbot/v2"
 )
 
 // https://github.com/OpenWonderLabs/SwitchBotAPI/blob/7a68353d84d07d439a11cb5503b634f24302f733/README.md#get-all-devices

--- a/example_test.go
+++ b/example_test.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/nasa9084/go-switchbot"
+	"github.com/nasa9084/go-switchbot/v2"
 )
 
 func ExamplePrintPhysicalDevices() {

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/nasa9084/go-switchbot
+module github.com/nasa9084/go-switchbot/v2
 
 go 1.19
 

--- a/scene_test.go
+++ b/scene_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
-	"github.com/nasa9084/go-switchbot"
+	"github.com/nasa9084/go-switchbot/v2"
 )
 
 // https://github.com/OpenWonderLabs/SwitchBotAPI/blob/7a68353d84d07d439a11cb5503b634f24302f733/README.md#get-all-scenes

--- a/webhook_test.go
+++ b/webhook_test.go
@@ -9,7 +9,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
-	"github.com/nasa9084/go-switchbot"
+	"github.com/nasa9084/go-switchbot/v2"
 )
 
 func TestWebhookSetup(t *testing.T) {


### PR DESCRIPTION
- https://go.dev/blog/v2-go-modules
- https://www.kaoriya.net/blog/2020/06/13/
- https://christina04.hatenablog.com/entry/go-modules-major-version

I'm sorry to bother you so much.
Thank you for a great tool.