### PR TITLE
fix: Status() error decoding JSON data: json: cannot unmarshal string…

### DIFF
--- a/device.go
+++ b/device.go
@@ -53,7 +53,7 @@ type Device struct {
 	LockDeviceIDs        []string           `json:"lockDeviceIds"`
 	LockDeviceID         string             `json:"lockDeviceId"`
 	KeyList              []KeyListItem      `json:"keyList"`
-	Version              int                `json:"version"`
+	Version              string             `json:"version"`
 	BlindTilts           []string           `json:"blindTiltDeviceIds"`
 	Direction            string             `json:"direction"`
 	SlidePosition        int                `json:"slidePosition"`
@@ -164,7 +164,7 @@ type DeviceStatus struct {
 	WorkingStatus          CleanerWorkingStatus `json:"workingStatus"`
 	OnlineStatus           CleanerOnlineStatus  `json:"onlineStatus"`
 	Battery                int                  `json:"battery"`
-	Version                int                  `json:"version"`
+	Version                string               `json:"version"`
 	Direction              string               `json:"direction"`
 }
 


### PR DESCRIPTION
Hi,

With go-switchbot v2.1.0, the function `Devices().Status(...)` returns the following error on my devices:
`error decoding JSON data: json: cannot unmarshal string into Go struct field DeviceStatus.body.version of type int.`

This patch resolves the error by replacing the `version` field's type with `string`.