### PR TITLE
fix type of Device.GroupName to string from bool

### DIFF
--- a/device.go
+++ b/device.go
@@ -49,7 +49,7 @@ type Device struct {
 	IsGrouped            bool               `json:"group"`
 	IsMaster             bool               `json:"master"`
 	OpenDirection        string             `json:"openDirection"`
-	GroupName            bool               `json:"groupName"` // is this Boolean, right?
+	GroupName            string             `json:"groupName"`
 	LockDeviceIDs        []string           `json:"lockDeviceIds"`
 	LockDeviceID         string             `json:"lockDeviceId"`
 	KeyList              []KeyListItem      `json:"keyList"`


### PR DESCRIPTION
日本語で失礼します。

SwitchBot スマートロックを2つ買ってグループ化(ツインロックに)したのですが、デバイス一覧をとると `Device.GroupName` は `string` で返されてきました。`bool` なのは `Device.Group` で、これが `true` の場合に `GroupName` が現れます。
`go-switchbot` では `Device.GroupName` が `bool` で記述されているため([公式ドキュメント](https://github.com/OpenWonderLabs/SwitchBotAPI)が間違ってますね) `Unmarshal` で失敗してしまいますので、このPRでは単純に `string` に書き換えます。(テストないですね)