### PR TITLE
add LightLevel for Hub 2

### DIFF
--- a/device.go
+++ b/device.go
@@ -151,6 +151,7 @@ type DeviceStatus struct {
 	ShakeRange             int                  `json:"shakeRange"`
 	IsMoveDetected         bool                 `json:"moveDetected"`
 	Brightness             BrightnessState      `json:"brightness"`
+	LightLevel             int                  `json:"lightLevel"`
 	OpenState              OpenState            `json:"openState"`
 	Color                  string               `json:"color"`
 	ColorTemperature       int                  `json:"colorTemperature"`


### PR DESCRIPTION
[Hub 2のドキュメント](https://github.com/OpenWonderLabs/SwitchBotAPI/blob/main/README.md#hub-2-1) にあるフィールドのうち、 `lightLevel` を追加します