### PR TITLE
Type of Lock is invalid name

### DIFF
--- a/switchbot.go
+++ b/switchbot.go
@@ -75,7 +75,7 @@ const (
 	// PlugMiniJP is SwitchBot Plug Mini (JP) Model No. W2001400
 	PlugMiniJP PhysicalDeviceType = "Plug Mini (JP)"
 	// Lock is SwitchBot Lock Model No. W1601700
-	Lock PhysicalDeviceType = "Lock"
+	Lock PhysicalDeviceType = "Smart Lock"
 	// RobotVacuumCleanerS1 is SwitchBot Robot Vacuum Cleaner S1 Model No. W3011000; currently only available in Japan
 	RobotVacuumCleanerS1 PhysicalDeviceType = "Robot Vacuum Cleaner S1"
 	// RobotVacuumCleanerS1Plus is SwitchBot Robot Vacuum Cleaner S1 Plus Model No. W3011010; currently only available in Japan


### PR DESCRIPTION
SmartLockのTypeが`Lock`になっていますが、[リファレンス上](https://github.com/OpenWonderLabs/SwitchBotAPI?tab=readme-ov-file#lock)で `Smart Lock` であると記載されています。

実際にAPIは手元のロックについて `"Smart Lock"` を返しており、`device.Type == switchbot.Lock` をすり抜けてしまっておりました。