### PR TITLE
Add MeterPro device support

### DIFF
--- a/device.go
+++ b/device.go
@@ -167,6 +167,7 @@ type DeviceStatus struct {
 	Battery                int                  `json:"battery"`
 	Version                DeviceVersion        `json:"version"`
 	Direction              string               `json:"direction"`
+	CO2                    int                  `json:"CO2"`
 }
 
 type PowerState string

--- a/switchbot.go
+++ b/switchbot.go
@@ -102,10 +102,12 @@ const (
 	IndoorCam PhysicalDeviceType = "Indoor Cam"
 	// PanTiltCam is SwitchBot Pan/Tilt Cam Model No. W1801200
 	PanTiltCam PhysicalDeviceType = "Pan/Tilt Cam"
-	//PanTiltCam2K is SwitchBot Pan/Tilt Cam 2K Model No. W3101100
+	// PanTiltCam2K is SwitchBot Pan/Tilt Cam 2K Model No. W3101100
 	PanTiltCam2K PhysicalDeviceType = "Pan/Tilt Cam 2K"
 	// BlindTilt is SwitchBot Blind Tilt Model No. W2701600
 	BlindTilt PhysicalDeviceType = "Blind Tilt"
+	// MeterPro is SwitchBot CO2 Sensor Model No. W4900010
+	MeterPro PhysicalDeviceType = "MeterPro"
 )
 
 type VirtualDeviceType string


### PR DESCRIPTION
いつも便利に使わせていただいています。

10月発売の SwitchBot CO2センサーが届いたので、対応してみました。
https://github.com/OpenWonderLabs/SwitchBotAPI/issues/352 によると、まだ API リファレンスでは undocumented なのですが API からレスポンスが返ってきていることを確認しています。

`GET /v1.1/devices HTTP/1.1`
```json5
{"statusCode":100,"body":{"deviceList":[...,{"deviceId":"xxx","deviceName":"CO2センサー（温湿度計） FA","deviceType":"MeterPro","enableCloudService":true,"hubDeviceId":""},...]},"message":"success"}
```

`GET /v1.1/devices/xxx/status HTTP/1.1`
```json
{"statusCode":100,"body":{"deviceId":"xxx","deviceType":"MeterPro","hubDeviceId":"xxx","humidity":55,"temperature":25.6,"CO2":931,"version":"V1.4","battery":100},"message":"success"}
```