### PR TITLE
Add MeterProCO2, Fix MeterPro

### DIFF
--- a/switchbot.go
+++ b/switchbot.go
@@ -106,8 +106,10 @@ const (
 	PanTiltCam2K PhysicalDeviceType = "Pan/Tilt Cam 2K"
 	// BlindTilt is SwitchBot Blind Tilt Model No. W2701600
 	BlindTilt PhysicalDeviceType = "Blind Tilt"
-	// MeterPro is SwitchBot CO2 Sensor Model No. W4900010
+	// MeterPro is SwitchBot Thermometer and Hygrometer Pro Model No. W4900000
 	MeterPro PhysicalDeviceType = "MeterPro"
+	// MeterPro(CO2) is SwitchBot CO2 Sensor Model No. W4900010
+	MeterProCO2 PhysicalDeviceType = "MeterPro(CO2)"
 )
 
 type VirtualDeviceType string


### PR DESCRIPTION
CO2センサー（温湿度計）と温湿度計ProのdeviceNameを正しいものに修正しました。
Ref: https://github.com/OpenWonderLabs/SwitchBotAPI/blob/0c4fa92e83dd995663dc29852a6569eadf3a451d/README.md#meter-pro
https://github.com/OpenWonderLabs/SwitchBotAPI/blob/0c4fa92e83dd995663dc29852a6569eadf3a451d/README.md#meter-pro-co2