### PR TITLE
Fix: Add battery level field to ContactSensorEventContext

### DIFF
--- a/webhook.go
+++ b/webhook.go
@@ -296,6 +296,8 @@ type ContactSensorEventContext struct {
 	Brightness AmbientBrightness `json:"brightness"`
 	// the state of the contact sensor, can be "open" or "close" or "timeOutNotClose"
 	OpenState string `json:"openState"`
+	// the current battery level, 0-100
+	Battery int `json:"battery"`
 }
 
 type MeterEvent struct {


### PR DESCRIPTION
This pull request adds the battery field to the ContactSensorEventContext struct to reflect the current SwitchBot API response format.

# 🛠 What’s Changed
```
// the current battery level, 0-100
Battery int `json:"battery"`
```
# 🔍 Reason
The official API response includes a battery field for contact sensor events, but the struct in this library did not reflect that. This causes unmarshaling to drop the field, which can be problematic if the battery level is needed.

# ✅ Compatibility
This change is backward-compatible. It only adds a new field and does not affect existing code using the struct.